### PR TITLE
Amp shutdown 2

### DIFF
--- a/src/amp.rs
+++ b/src/amp.rs
@@ -1,34 +1,94 @@
-use rppal::gpio::{Error, Gpio};
+use rppal::gpio::{Error, Gpio, OutputPin};
+use std::sync::Arc;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};
+use tokio::sync::{oneshot, Mutex};
 use tokio::task::JoinSet;
-use tracing::error;
+use tracing::{debug, error, warn};
 
-pub struct Amp {}
+pub enum AmpControlMessage {
+    On { responder: oneshot::Sender<()> },
+    Off { responder: oneshot::Sender<()> },
+}
+
+#[derive(Clone)]
+pub struct Amp {
+    sender: Arc<Mutex<UnboundedSender<AmpControlMessage>>>,
+}
 
 impl Amp {
     const AMP_SD_GPIO_PIN: u8 = 21;
 
-    pub async fn new(join_set: &mut JoinSet<()>) -> Result<UnboundedSender<bool>, Error> {
-        let mut pin = Gpio::new()?.get(Amp::AMP_SD_GPIO_PIN)?.into_output();
+    pub async fn new(join_set: &mut JoinSet<()>) -> Result<Self, Error> {
+        let mut pin = Self::get_pin().ok();
 
-        pin.set_low();
-
-        let (sender, mut receiver) = unbounded_channel::<bool>();
+        let (sender, mut receiver) = unbounded_channel::<AmpControlMessage>();
 
         join_set.spawn(async move {
             loop {
                 let message = receiver.recv().await;
 
                 match message {
-                    Some(enable) => match enable {
-                        true => pin.set_high(),
-                        false => pin.set_low(),
+                    Some(message) => match message {
+                        AmpControlMessage::On { responder } => {
+                            match &mut pin {
+                                Some(pin) => pin.set_high(),
+                                None => warn!("couldn't set amp amp to high, no pin"),
+                            }
+                            match responder.send(()) {
+                                Ok(_) => {}
+                                Err(_) => error!("error sending amp on message response"),
+                            };
+                        }
+                        AmpControlMessage::Off { responder } => {
+                            match &mut pin {
+                                Some(pin) => pin.set_low(),
+                                None => warn!("couldn't set amp amp to low, no pin"),
+                            }
+                            match responder.send(()) {
+                                Ok(_) => {}
+                                Err(_) => error!("error sending amp off message response"),
+                            };
+                        }
                     },
                     None => error!("amp channel closed"),
                 };
             }
         });
 
-        Ok(sender)
+        let sender = Arc::new(Mutex::new(sender));
+
+        Ok(Amp { sender })
+    }
+
+    fn get_pin() -> Result<OutputPin, Error> {
+        let mut pin: OutputPin = Gpio::new()?.get(Amp::AMP_SD_GPIO_PIN)?.into_output();
+        pin.set_low();
+        Ok(pin)
+    }
+
+    pub async fn on(&self) -> Result<(), tokio::sync::oneshot::error::RecvError> {
+        let sender = self.sender.lock().await;
+        let (response_sender, response_receiver) = oneshot::channel::<()>();
+        match sender.send(AmpControlMessage::On {
+            responder: response_sender,
+        }) {
+            Ok(_) => debug!("submitted amp on request"),
+            Err(e) => error!("error submitting amp on request: {e}"),
+        };
+
+        response_receiver.await
+    }
+
+    pub async fn off(&self) -> Result<(), tokio::sync::oneshot::error::RecvError> {
+        let sender = self.sender.lock().await;
+        let (response_sender, response_receiver) = oneshot::channel::<()>();
+        match sender.send(AmpControlMessage::Off {
+            responder: response_sender,
+        }) {
+            Ok(_) => debug!("submitted amp off request"),
+            Err(e) => error!("error submitting amp off request: {e}"),
+        };
+
+        response_receiver.await
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,13 +29,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut join_set = JoinSet::<()>::new();
 
-    let amp_sender = Amp::new(&mut join_set).await?;
-    let amp_sender_player = amp_sender.clone();
+    let amp = Amp::new(&mut join_set).await?;
+    let amp_player = amp.clone();
 
     let (sender, receiver) = mpsc::channel::<PlayerRequestMessage>(16);
-    let app_state = AppState { sender, amp_sender };
+    let app_state = AppState { sender, amp };
 
-    start_player_task(&mut join_set, receiver, amp_sender_player).await?;
+    start_player_task(&mut join_set, receiver, amp_player).await?;
     start_ntag_reader_task(&mut join_set, app_state.clone()).await;
     start_server_task(&mut join_set, app_state.clone()).await;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,12 +30,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut join_set = JoinSet::<()>::new();
 
     let amp_sender = Amp::new(&mut join_set).await?;
-    amp_sender.send(true)?;
+    let amp_sender_player = amp_sender.clone();
 
     let (sender, receiver) = mpsc::channel::<PlayerRequestMessage>(16);
     let app_state = AppState { sender, amp_sender };
 
-    start_player_task(&mut join_set, receiver).await?;
+    start_player_task(&mut join_set, receiver, amp_sender_player).await?;
     start_ntag_reader_task(&mut join_set, app_state.clone()).await;
     start_server_task(&mut join_set, app_state.clone()).await;
 


### PR DESCRIPTION
Message passing based async amp power control.
* Easier interface for amp power control
* amp power control "fails" transparently, so it can run on non-RPi hosts again
* amp turns on when playback starts, turns off when it ends **this needs testing on the target**