### PR TITLE
Checking that service exists before attempting to stop it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ copy:
 	scp service/drempelbox.service ${RPI_HOST}:${RPI_TEMP_PATH}/drempelbox.service
 	scp target/aarch64-unknown-linux-gnu/release/drempelbox ${RPI_HOST}:${RPI_TEMP_PATH}/drempelbox
 
-	if systemctl is-active --quiet service; then \
+	if ssh ${RPI_HOST} sudo systemctl is-active --quiet drempelbox; then \
 		ssh ${RPI_HOST} sudo systemctl stop drempelbox; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,9 @@ copy:
 	scp service/drempelbox.service ${RPI_HOST}:${RPI_TEMP_PATH}/drempelbox.service
 	scp target/aarch64-unknown-linux-gnu/release/drempelbox ${RPI_HOST}:${RPI_TEMP_PATH}/drempelbox
 
-	ssh ${RPI_HOST} sudo systemctl stop drempelbox
+	if systemctl is-active --quiet service; then \
+		ssh ${RPI_HOST} sudo systemctl stop drempelbox; \
+	fi
 
 	ssh ${RPI_HOST} sudo mv ${RPI_TEMP_PATH}/drempelbox /usr/bin/drempelbox
 	ssh ${RPI_HOST} sudo mv ${RPI_TEMP_PATH}/drempelbox.service /etc/systemd/system/drempelbox.service


### PR DESCRIPTION
`make copy` attempts to stop the drempelbox service before copying the new unit file. That fails, however, on the very first run when the unit file doesn't exist yet.