### PR TITLE
Use specifier %u in service file to determine current user

### DIFF
--- a/service/drempelbox.service
+++ b/service/drempelbox.service
@@ -8,7 +8,7 @@ StartLimitIntervalSec=0
 Type=simple
 Restart=always
 RestartSec=5
-User=marcf
+User=%u
 ExecStart=/usr/bin/drempelbox
 CacheDirectory=drempelbox
 Environment=RUST_BACKTRACE=full RUST_LOG=DEBUG XDG_RUNTIME_DIR=/run/user/1000


### PR DESCRIPTION
Had the problem that the services existed with `status=217/USER`. This was due to the hardcoded user in the service definition that doesn't exist on my machine. Replacing the username with the `%u` specifier seems to the issue.

However... The service now runs as root, I'm so far not sure if this doesn't entail adverse effects. Keeping it as a draft PR for now and would appreciate feedback.