### PR TITLE
Added ExecStartPre command to service file to set alsa speaker level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -967,6 +967,7 @@ dependencies = [
 name = "drempelbox"
 version = "0.1.0"
 dependencies = [
+ "alsa",
  "async-std",
  "axum",
  "bitflags 2.8.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ pin-project-lite = "0.2.16"
 percent-encoding = "2.3.1"
 rppal = { version = "0.22.1", features = ["hal"] }
 system_shutdown = "4.0.1"
+alsa = "0.9.1"

--- a/service/drempelbox.service
+++ b/service/drempelbox.service
@@ -9,7 +9,6 @@ Type=simple
 Restart=always
 RestartSec=5
 User=drempelbox
-ExecStartPre=amixer -c 0 set Speaker 90%
 ExecStart=/usr/bin/drempelbox
 CacheDirectory=drempelbox
 Environment=RUST_BACKTRACE=full RUST_LOG="WARN,drempelbox=DEBUG" XDG_RUNTIME_DIR=/run/user/1337

--- a/service/drempelbox.service
+++ b/service/drempelbox.service
@@ -9,6 +9,7 @@ Type=simple
 Restart=always
 RestartSec=5
 User=drempelbox
+ExecStartPre=amixer -c 0 set Speaker 90%
 ExecStart=/usr/bin/drempelbox
 CacheDirectory=drempelbox
 Environment=RUST_BACKTRACE=full RUST_LOG="WARN,drempelbox=DEBUG" XDG_RUNTIME_DIR=/run/user/1337

--- a/src/alsa.rs
+++ b/src/alsa.rs
@@ -1,0 +1,32 @@
+use alsa::mixer::SelemId;
+use alsa::{Error, Mixer};
+use tokio::task::JoinSet;
+use tracing::info;
+
+#[derive(Clone)]
+pub struct Alsa {}
+
+impl Alsa {
+    const TARGET_VOLUME_PERCENT: i64 = 80;
+
+    pub async fn new(_join_set: &mut JoinSet<()>) -> Result<Self, Error> {
+        let mixer = Mixer::new("default", false).expect("Failed to open mixer.");
+        let selem_id = SelemId::new("Master", 0);
+        let selem = mixer
+            .find_selem(&selem_id)
+            .expect("Failed to find mixer control.");
+        let (min, max) = selem.get_playback_volume_range();
+        let target_volume = (max - min) * Self::TARGET_VOLUME_PERCENT / 100 + min;
+        selem
+            .set_playback_volume_all(target_volume)
+            .expect("Failed to set volume.");
+        info!(
+            "Setting volume to {} ({}% of range {} - {}).",
+            target_volume,
+            Self::TARGET_VOLUME_PERCENT,
+            min,
+            max
+        );
+        Ok(Self {})
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,11 +35,16 @@ use crate::volume_buttons::VolumeButtons;
 pub mod led;
 use crate::led::Led;
 
+pub mod alsa;
+use crate::alsa::Alsa;
+
 #[tokio::main()]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
     let mut join_set = JoinSet::<()>::new();
+
+    let _alsa = Alsa::new(&mut join_set).await?;
 
     let amp = Amp::new(&mut join_set).await?;
     let amp_player = amp.clone();


### PR DESCRIPTION
`alsactl store` wouldn't work for me across reboots, meaning that my alsamixer settings always got lost. There's plenty of discussions around the net about this issue. The easiest fix seems to be this one. Disadvantage: Whatever you set in alsamixer during a session gets lost once the program restarts (e.g., after a `make bca`).